### PR TITLE
Hotfix/src menu.js

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -25,11 +25,12 @@ export class ContextMenu extends Menu {
     const menuItem = document.createElement('li')
     menuItem.classList.add('menu-item')
     menuItem.dataset.type = module.type
-    menuItem.textContent = module.text
-    menuItem.addEventListener('click', () => {
-      module.trigger()
-      this.close()
-    })
+    if (module.render) {
+      menuItem.append(module.render())
+    } else {
+      menuItem.textContent = module.text
+    }
+    menuItem.addEventListener('click', () => module.trigger())
     this.menu.append(menuItem)
   }
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -30,7 +30,10 @@ export class ContextMenu extends Menu {
     } else {
       menuItem.textContent = module.text
     }
-    menuItem.addEventListener('click', () => module.trigger())
+    menuItem.addEventListener('click', () => {
+      module.trigger()
+      this.close()
+    })
     this.menu.append(menuItem)
   }
 


### PR DESCRIPTION
Обновление src/menu.js метода add()
-Добавлена возможность модифицировать вид стандартного модуля
контекстного меню через render()
-Функция по прежнему реализуется внутри trigger()

**For what?
-Икапсуляция кода - нет повторяющихся элементов toHTML
-Исправление не конфликтует с предыдущими версиями модулей
-Реализовано для модуля Таймера